### PR TITLE
feat: instance accessibility for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![](https://github.com/jpoehnelt/in-solidarity-bot/raw/main/static//badge-flat.png)](https://github.com/apps/in-solidarity)
 [![Discord](https://img.shields.io/discord/676948200904589322?color=6A7EC2&logo=discord&logoColor=ffffff)](https://discord.gg/jRteCzP)
 
-
 ## Description
 
 Jest mocks for Google Maps in TypeScript.
@@ -23,12 +22,16 @@ Available via NPM as the package `@googlemaps/jest-mocks`
 ## Example
 
 ```typescript
-import { initialize } from "@googlemaps/jest-mocks";
+import { initialize, Map } from "@googlemaps/jest-mocks";
 
 beforeEach(() => {
   initialize();
 });
 
+// access the object instances if the object isn't easily accessible
+test("my test", () => {
+  expect(Map.mockInstances[0].fitBounds).toHaveBeenCalled();
+});
 ```
 
 ## Support

--- a/src/maps/event/mvcobject.test.ts
+++ b/src/maps/event/mvcobject.test.ts
@@ -1,3 +1,5 @@
+import { initialize } from "../../index";
+import { Map_ } from "../maps/map";
 import { MVCObject } from "./mvcobject";
 
 test("instances are stored", () => {
@@ -6,6 +8,14 @@ test("instances are stored", () => {
   expect(MVCObject.mockInstances[0].addListener).toBeTruthy();
 });
 
-test("instances are cleared after the test above", () => {
-  expect(MVCObject.mockInstances).toStrictEqual([]);
+test("setup child class", () => {
+  initialize();
+  new google.maps.Map(null);
+  expect(Map_.mockInstances).toBeTruthy();
+});
+
+test("auto cleanup after each test from above", () => {
+  expect(MVCObject.mockInstances).toBeUndefined();
+  expect(Map_.mockInstances).toBeUndefined();
+  expect(MVCObject._mockClasses).toBeUndefined();
 });

--- a/src/maps/event/mvcobject.test.ts
+++ b/src/maps/event/mvcobject.test.ts
@@ -1,0 +1,11 @@
+import { MVCObject } from "./mvcobject";
+
+test("instances are stored", () => {
+  const mvcObject = new MVCObject();
+  expect(MVCObject.mockInstances).toStrictEqual([mvcObject]);
+  expect(MVCObject.mockInstances[0].addListener).toBeTruthy();
+});
+
+test("instances are cleared after the test above", () => {
+  expect(MVCObject.mockInstances).toStrictEqual([]);
+});

--- a/src/maps/event/mvcobject.ts
+++ b/src/maps/event/mvcobject.ts
@@ -17,6 +17,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export class MVCObject implements google.maps.MVCObject {
+  public static mockInstances: MVCObject[] = [];
+
+  public constructor() {
+    MVCObject.mockInstances.push(this);
+  }
+
   public addListener = jest
     .fn()
     .mockImplementation(
@@ -41,4 +47,12 @@ export class MVCObject implements google.maps.MVCObject {
   public setValues = jest.fn().mockImplementation((values: any): void => null);
   public unbind = jest.fn().mockImplementation((key: string): void => null);
   public unbindAll = jest.fn().mockImplementation(() => null);
+}
+
+// if running a test that supports afterEach, then we will cleanup the instances
+// automatically at the end of each test.
+if (typeof afterEach === "function") {
+  afterEach(() => {
+    MVCObject.mockInstances = [];
+  });
 }

--- a/src/maps/event/mvcobject.ts
+++ b/src/maps/event/mvcobject.ts
@@ -17,10 +17,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export class MVCObject implements google.maps.MVCObject {
+  public static _mockClasses: typeof MVCObject[] = [];
   public static mockInstances: MVCObject[] = [];
 
   public constructor() {
-    MVCObject.mockInstances.push(this);
+    const ctor = this.constructor as typeof MVCObject;
+
+    if (ctor.mockInstances === undefined) {
+      ctor.mockInstances = [];
+    }
+
+    if (MVCObject._mockClasses === undefined) {
+      MVCObject._mockClasses = [];
+    }
+
+    ctor.mockInstances.push(this);
+    MVCObject._mockClasses.push(ctor);
   }
 
   public addListener = jest
@@ -53,6 +65,11 @@ export class MVCObject implements google.maps.MVCObject {
 // automatically at the end of each test.
 if (typeof afterEach === "function") {
   afterEach(() => {
-    MVCObject.mockInstances = [];
+    if (MVCObject._mockClasses) {
+      for (const ctor of MVCObject._mockClasses) {
+        ctor.mockInstances = undefined;
+      }
+    }
+    MVCObject._mockClasses = undefined;
   });
 }

--- a/src/maps/maps/map.test.ts
+++ b/src/maps/maps/map.test.ts
@@ -16,6 +16,7 @@
 
 import { initialize } from "../../index";
 import { ControlPosition } from "../controls/controlposition";
+import { Map_ } from "./map";
 
 test("can initialize", () => {
   initialize();
@@ -26,4 +27,10 @@ test("controls initialized", () => {
   initialize();
   const map = new google.maps.Map(null);
   expect(map.controls[ControlPosition.BOTTOM_CENTER]).toBeTruthy();
+});
+
+test("mockInstances available", () => {
+  initialize();
+  const map = new google.maps.Map(null);
+  expect(Map_.mockInstances[0]).toStrictEqual(map);
 });

--- a/src/maps/maps/map.test.ts
+++ b/src/maps/maps/map.test.ts
@@ -22,7 +22,7 @@ test("can initialize", () => {
   expect(new google.maps.Map(null)).toBeTruthy();
 });
 
-test("controls initalized", () => {
+test("controls initialized", () => {
   initialize();
   const map = new google.maps.Map(null);
   expect(map.controls[ControlPosition.BOTTOM_CENTER]).toBeTruthy();

--- a/src/maps/maps/map.test.ts
+++ b/src/maps/maps/map.test.ts
@@ -31,6 +31,7 @@ test("controls initialized", () => {
 
 test("mockInstances available", () => {
   initialize();
+  new google.maps.MVCObject();
   const map = new google.maps.Map(null);
-  expect(Map_.mockInstances[0]).toStrictEqual(map);
+  expect(Map_.mockInstances).toMatchObject([map]);
 });


### PR DESCRIPTION
Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #175  🦕

---

This patch provides accessibility to the class instances that are created as "mocks".  Because each class is defined as such, and not as a jest function, we are not able to retrieve the instances as we normally would in jest:

```typescript
import { Map } from "@googlemaps/jest-mocks";

test('fail', () => {
  const mapMock = google.maps.Map as jest.Mock;
  expect(mapMock.fitBounds).toHaveBeenCalled();
});

test('success', () => {
  const mapMock = Map.mockInstances[0];
  expect(mapMock.fitBounds).toHaveBeenCalled();
});

```

An alternative solution, may be to redefine each class a a jest function so that this works more natively, and there is less overhead for natural jest unit test development.
