### PR TITLE
Fix/data object on map instance

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": false,
+  "endOfLine": "auto"
+}

--- a/src/maps/maps/map.test.ts
+++ b/src/maps/maps/map.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { initialize } from "../../index";
+import { Data } from "../../drawing/data/data";
 import { ControlPosition } from "../controls/controlposition";
 import { Map_ } from "./map";
 
@@ -27,6 +28,14 @@ test("controls initialized", () => {
   initialize();
   const map = new google.maps.Map(null);
   expect(map.controls[ControlPosition.BOTTOM_CENTER]).toBeTruthy();
+});
+
+test("map instance has data object", () => {
+  initialize();
+  new google.maps.MVCObject();
+  const map = new google.maps.Map(null);
+  expect(map.data).toBeTruthy();
+  expect(map.data).toBeInstanceOf(Data);
 });
 
 test("mockInstances available", () => {

--- a/src/maps/maps/map.ts
+++ b/src/maps/maps/map.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Data } from "../../drawing/data/data";
 import { LatLng, LatLngBounds } from "../coordinates/latlng";
 import { MVCObject } from "../event/mvcobject";
 
@@ -25,7 +26,7 @@ export class Map_ extends MVCObject implements google.maps.Map {
 
   constructor(mapDiv: Element | null, opts?: google.maps.MapOptions) {
     super();
-    this.data = new google.maps.Data();
+    this.data = new Data();
     this.controls = [
       new google.maps.MVCArray<Node>(), // BOTTOM_CENTER
       new google.maps.MVCArray<Node>(), // BOTTOM_LEFT


### PR DESCRIPTION
The data object was already mocked correctly but not used when a map instance was created. This PR fixes this.
Also, if you don't mind, I added a prettier config file for those who have a global prettier installation. Having correct formatting on save is easier than running the linter every time. Let me know if this is fine for you.

Cheers!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #141 🦕
