### PR TITLE
Export Places Autocomplete and SearchBox

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ const initialize = function (): void {
 };
 
 export {
+  Autocomplete,
   Circle,
   Data,
   event,
@@ -108,6 +109,7 @@ export {
   Point,
   Polygon,
   Polyline,
+  SearchBox,
   Size,
   StreetViewCoverageLayer,
   StreetViewPanorama,


### PR DESCRIPTION
Sorry I haven't opened an issue for this, I forked the repo to see if exporting the Autocomplete class worked for my testing need.

FYI - this change fixed my problem to allow 

```typescript
beforeEach(() => {
  initialize();
});

describe("GooglePlaceAutocomplete", () => {
  const callback = jest.fn();

  const requiredProps = {
    initialValue: undefined,
    callback,
  };

  const renderComponent = (props = requiredProps) =>
    render(<GooglePlaceAutocomplete {...props} />);

  it("renders", async () => {
    renderComponent();

    const autoComplete = mockInstances.get(Autocomplete)[0];

    act(() => {
      autoComplete.addListener.mock.calls[0][1]();
    });

    await waitFor(() => {
      expect(
        screen.getByTestId("google-place-autocomplete")
      ).toBeInTheDocument();
      expect(autoComplete.addListener).toBeCalledTimes(1);
      expect(autoComplete.getPlace).toBeCalled();
      expect(callback).toBeCalledWith({ name: "" });
    });
  });
});
```
