### PR TITLE
feat: data.polygon mock and add feature to registry

### DIFF
--- a/src/drawing/data/data.feature.ts
+++ b/src/drawing/data/data.feature.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-export class Feature implements google.maps.Data.Feature {
-  constructor(options?: google.maps.Data.FeatureOptions | null) {}
+ import { MVCObject } from "../../maps/event/mvcobject";
+
+export class Feature extends MVCObject implements google.maps.Data.Feature {
+  constructor(options?: google.maps.Data.FeatureOptions | null) {
+    super();
+  }
   public forEachProperty = jest
     .fn()
     .mockImplementation((callback: (a: any, b: string) => void) => {

--- a/src/drawing/data/data.feature.ts
+++ b/src/drawing/data/data.feature.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- import { MVCObject } from "../../maps/event/mvcobject";
+import { MVCObject } from "../../maps/event/mvcobject";
 
 export class Feature extends MVCObject implements google.maps.Data.Feature {
   constructor(options?: google.maps.Data.FeatureOptions | null) {

--- a/src/drawing/data/data.polygon.test.ts
+++ b/src/drawing/data/data.polygon.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { initialize } from "../../index";
+
+test("feature object is mocked", () => {
+  initialize();
+  expect(new google.maps.Data.Polygon(null)).toBeTruthy();
+});

--- a/src/drawing/data/data.polygon.ts
+++ b/src/drawing/data/data.polygon.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MVCObject } from "../../maps/event/mvcobject";
+
+export class DataPolygon extends MVCObject implements google.maps.Data.Polygon {
+  constructor(
+    elements?:
+      | google.maps.MVCArray<google.maps.MVCArray<google.maps.LatLng>>
+      | google.maps.MVCArray<google.maps.LatLng>
+      | google.maps.LatLng[][]
+      | google.maps.LatLngLiteral[][]
+      | google.maps.LatLng[]
+      | google.maps.LatLngLiteral[]
+  ) {
+    super();
+  }
+  public forEachLatLng = jest
+    .fn()
+    .mockImplementation((callback: (a: google.maps.LatLng) => void): void => {
+      return null;
+    });
+  public getArray = jest
+    .fn()
+    .mockImplementation(
+      (): google.maps.MVCArray<google.maps.LatLng>[] =>
+        [] as google.maps.MVCArray<google.maps.LatLng>[]
+    );
+  public getAt = jest
+    .fn()
+    .mockImplementation(
+      (): google.maps.MVCArray<google.maps.LatLng> | null => null
+    );
+  public getLength = jest.fn().mockImplementation((): number => 0);
+  public getType = jest.fn().mockImplementation((): string => "MultiPolygon");
+}

--- a/src/drawing/data/data.ts
+++ b/src/drawing/data/data.ts
@@ -17,6 +17,7 @@
 import { ControlPosition } from "../../maps/controls/controlposition";
 import { MVCObject } from "../../maps/event/mvcobject";
 import { Feature } from "./data.feature";
+import { DataPolygon } from "./data.polygon";
 
 export class Data extends MVCObject implements google.maps.Data {
   constructor(opt?: google.maps.Data.DataOptions | null) {
@@ -28,6 +29,19 @@ export class Data extends MVCObject implements google.maps.Data {
       (
         options?: google.maps.Data.FeatureOptions | null
       ): google.maps.Data.Feature => new Feature(options)
+    );
+  public static Polygon = jest
+    .fn()
+    .mockImplementation(
+      (
+        elements?:
+          | google.maps.MVCArray<google.maps.MVCArray<google.maps.LatLng>>
+          | google.maps.MVCArray<google.maps.LatLng>
+          | google.maps.LatLng[][]
+          | google.maps.LatLngLiteral[][]
+          | google.maps.LatLng[]
+          | google.maps.LatLngLiteral[]
+      ): google.maps.Data.Polygon => new DataPolygon(elements)
     );
   public add = jest
     .fn()

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { LatLng, LatLngBounds } from "./maps/coordinates/latlng";
 import { Autocomplete } from "./places/autocomplete";
 import { Circle } from "./drawing/polygons/circle";
 import { Data } from "./drawing/data/data";
+import { DataPolygon } from "./drawing/data/data.polygon";
 import { Feature } from "./drawing/data/data.feature";
 import { MVCArray } from "./maps/event/mvcarray";
 import { MVCObject } from "./maps/event/mvcobject";
@@ -93,6 +94,7 @@ const initialize = function (): void {
 export {
   Circle,
   Data,
+  DataPolygon,
   event,
   Feature,
   LatLng,


### PR DESCRIPTION
Feature: `Data.Polygon` mock, a sub-class of `Data` with methods that are unique from `Polygon`.
https://developers.google.com/maps/documentation/javascript/reference/data#Data.Polygon
To allow `mockInstances.get`, `DataPolygon` is exported.

Bug fix: `Feature` is extended from `MVCObject` so that instances are added to the registry.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #303 🦕

Fixes #304  🦕

