### PR TITLE
fix: return actual sv instance for map method

### DIFF
--- a/src/maps/maps/map.ts
+++ b/src/maps/maps/map.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { StreetViewPanorama } from "../../street-view/rendering/panorama";
 import { LatLng, LatLngBounds } from "../coordinates/latlng";
 import { MVCObject } from "../event/mvcobject";
 
@@ -79,10 +80,7 @@ export class Map_ extends MVCObject implements google.maps.Map {
     );
   public getStreetView = jest
     .fn()
-    .mockImplementation(
-      (): google.maps.StreetViewPanorama =>
-        jest.fn() as unknown as google.maps.StreetViewPanorama
-    );
+    .mockImplementation(() => new StreetViewPanorama());
   public getTilt = jest.fn().mockImplementation((): number => 0);
   public getZoom = jest.fn().mockImplementation((): number => 0);
   public moveCamera = jest


### PR DESCRIPTION
`google.maps.Map.getStreetView()` now returns an actual (mock) instance of a Street View panorama.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #324  🦕
