### PR TITLE
feat(autocomplete): Add AutocompleteSessionToken Mocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { Geocoder } from "./places/geocoder/geocoder";
 import { Autocomplete } from "./places/autocomplete";
 import { MaxZoomService } from "./drawing/max-zoom/max-zoom";
 import { AutocompleteService } from "./places/autocomplete-service/autocomplete-service";
+import { AutocompleteSessionToken } from "./places/autocomplete-session-token/autocomplete-session-token";
 import { DistanceMatrixService } from "./routes/distance-matrix-service/distance-matrix-service";
 import { ElevationService } from "./routes/elevation-service/elevation-service";
 import { Circle } from "./drawing/polygons/circle";
@@ -91,6 +92,7 @@ const initialize = function (): void {
         SearchBox: SearchBox,
         PlacesService,
         AutocompleteService,
+        AutocompleteSessionToken,
       },
       Geocoder,
       Polygon: Polygon,
@@ -120,6 +122,7 @@ export {
   Autocomplete,
   PlacesService,
   AutocompleteService,
+  AutocompleteSessionToken,
   Geocoder,
   Circle,
   Data,

--- a/src/places/autocomplete-session-token/autocomplete-session-token.test.ts
+++ b/src/places/autocomplete-session-token/autocomplete-session-token.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2023 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AutocompleteSessionToken,
+  initialize,
+  mockInstances,
+} from "../../index";
+
+beforeEach(initialize);
+
+test("autocomplete session token is mocked", async () => {
+  const token = new google.maps.places.AutocompleteSessionToken();
+
+  expect(token).toBeTruthy();
+});
+
+test("register mocks", () => {
+  new google.maps.places.AutocompleteSessionToken();
+  const mocks = mockInstances.get(AutocompleteSessionToken);
+
+  expect(mocks).toHaveLength(1);
+});

--- a/src/places/autocomplete-session-token/autocomplete-session-token.ts
+++ b/src/places/autocomplete-session-token/autocomplete-session-token.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2023 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { __registerMockInstance } from "../../registry";
+
+export class AutocompleteSessionToken
+  implements google.maps.places.AutocompleteSessionToken
+{
+  constructor() {
+    __registerMockInstance(this.constructor, this);
+  }
+}


### PR DESCRIPTION
Hi there - thanks for making a great library!

Previously the `google.maps.places.AutocompleteSessionToken` class was not mocked by this library.

Developers implementing custom autocomplete operations would likely encounter the following error message in their tests:

```
TypeError: google.maps.places.AutocompleteSessionToken is not a constructor
```

This PR adds a mock and exports it for the `AutocompleteSessionToken` class. The constructor accepts no parameters, and the class does not expose any public functions/methods ([docs](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteSessionToken)).

resolves #495

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- ~[] Appropriate docs were updated (if necessary)~
