### PR TITLE
fix: DirectionsService.route contains the request in its response

### DIFF
--- a/src/routes/directions-service/directions-service.ts
+++ b/src/routes/directions-service/directions-service.ts
@@ -29,6 +29,7 @@ export class DirectionsService implements google.maps.DirectionsService {
       ) => void
     ): Promise<google.maps.DirectionsResult> =>
       Promise.resolve({
+        request,
         routes: [] as Array<google.maps.DirectionsRoute>,
         available_travel_modes: [] as Array<google.maps.TravelMode>,
         geocoded_waypoints: [] as Array<google.maps.DirectionsGeocodedWaypoint>,


### PR DESCRIPTION
The `response.request` property was missing from the mock implementation, causing typescript errors when compiling and using.