### PR TITLE
chore: update release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,4 +72,4 @@ jobs:
         # npm publish will trigger the build via the prepack hook
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_WOMBAT_TOKEN }}


### PR DESCRIPTION
The new Release Please workflow is [failing](https://github.com/googlemaps/js-jest-mocks/actions/runs/7002934684/job/19047651075) due to auth failure during npm publishing. This fixes the secret name.