### PR TITLE
fix: initialize element property of AdvancedMarkerElement

### DIFF
--- a/src/drawing/advanced-marker-element/advanced-marker-element.test.ts
+++ b/src/drawing/advanced-marker-element/advanced-marker-element.test.ts
@@ -42,4 +42,6 @@ test("registers mocks", () => {
   });
 
   expect(mockInstances.get(AdvancedMarkerElement)[0].title).toBe("Howdy");
+
+  expect(mockInstances.get(AdvancedMarkerElement)[0].element).toBeDefined();
 });

--- a/src/drawing/advanced-marker-element/advanced-marker-element.ts
+++ b/src/drawing/advanced-marker-element/advanced-marker-element.ts
@@ -49,6 +49,9 @@ export class AdvancedMarkerElement
 
   constructor(options?: google.maps.marker.AdvancedMarkerElementOptions) {
     super();
+
+    this.element = document.createElement("div");
+
     __registerMockInstance(this.constructor, this);
   }
 }


### PR DESCRIPTION
Add initialization of the `advancedMarkerEl.element` property. In the real API this is initialized in the constructor and is guaranteed to be an html-element, so it has to be here as well.