### PR TITLE
fix: add google.maps.Animation mock

### DIFF
--- a/src/drawing/marker/constants.test.ts
+++ b/src/drawing/marker/constants.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { initialize } from "../../index";
+
+test("animation constants", () => {
+  initialize();
+  expect(google.maps.Animation).toMatchObject({
+    BOUNCE: 0,
+    DROP: 1,
+  });
+});

--- a/src/drawing/marker/constants.ts
+++ b/src/drawing/marker/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum Animation {
+  BOUNCE = 0,
+  DROP = 1,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ import { PinElement } from "./drawing/advanced-marker-element/pin-element";
 import { FeatureLayer } from "./maps/maps/featurelayer";
 import { event } from "./maps/event/event";
 import { mockInstances } from "./registry";
+import { Animation } from "./drawing/marker/constants";
 
 const initialize = function (): void {
   mockInstances.clearAll();
@@ -79,6 +80,7 @@ const initialize = function (): void {
       Size: Size,
       MVCObject: MVCObject,
       MVCArray: MVCArray,
+      Animation: Animation,
       MapTypeId: MapTypeId,
       ControlPosition: ControlPosition,
       LatLng: LatLng,
@@ -168,5 +170,6 @@ export {
   FeatureLayer,
   importLibrary,
   mockInstances,
+  Animation,
   initialize,
 };


### PR DESCRIPTION
Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #332  🦕

This PR adds the missing `google.maps.Animation` mock with `BOUNCE` and `DROP` constants.

After calling `initialize()`, users can now access:

```ts
google.maps.Animation.BOUNCE
google.maps.Animation.DROP
```

This fixes the issue where code using `google.maps.Animation.BOUNCE` could fail in tests because `google.maps.Animation` was not defined.

This PR also adds tests to verify that `google.maps.Animation` is initialized with `BOUNCE` and `DROP`.

Tests passed:
- npm test
- npm run lint

I am happy to update the code if any changes are needed.